### PR TITLE
Copy files with a preference of the source module's classes and warn only on copying errors

### DIFF
--- a/src/main/groovy/eu/appsatori/gradle/fatjar/tasks/PrepareFiles.groovy
+++ b/src/main/groovy/eu/appsatori/gradle/fatjar/tasks/PrepareFiles.groovy
@@ -46,11 +46,19 @@ class PrepareFiles extends DefaultTask {
         }
 
         if(resourcesDir?.exists()){
-            ant.copy(todir: stageDir, failonerror: false) { fileset(dir: resourcesDir) }
+            // force: true, overwrite:true because we want the user's project to always win
+            // failOnerror: false to be compatible with case-insentive file systems
+            ant.copy(todir: stageDir, force: true, overwrite: true, failOnError: false) {
+                fileset(dir: resourcesDir)
+            }
         }
 
         if(classesDir?.exists()){
-            ant.copy(todir: stageDir, failonerror: false){ fileset(dir: classesDir) }
+            // force: true, overwrite:true because we want the user's project to always win
+            // failOnerror: false to be compatible with case-insentive file systems
+            ant.copy(todir: stageDir, force: true, overwrite: true, failOnError: false) {
+                fileset(dir: classesDir)
+            }
         }
 
         FileTree filesToMerge = files.asFileTree.matching filter
@@ -61,11 +69,15 @@ class PrepareFiles extends DefaultTask {
         }
 
         filesToMerge.visit { FileTreeElement file ->
-            if(file.isDirectory()) return
-                File theFile = new File(stageDir, file.relativePath.toString())
+            if(file.isDirectory())
+                return
+
+            File theFile = new File(stageDir, file.relativePath.toString())
+
             if(!theFile.exists()){
                 theFile.createNewFile()
             }
+
             theFile.append file.file.text.trim() + '\n'
         }
     }


### PR DESCRIPTION
Set Ant copy task properties to appropriate defaults for an assembled fat jar. This matches the default behavior of the Maven assembly plugin.

_force: true, overwrite:true_
Prefer the module's classes when overwriting a file. At runtime, this is equivalent to using the classpath ordering to override classes with an alternative implementation.

_failOnError: false_
Prefer warning when a copying a file fails instead of halting the task. This resolves compatibility on case-insensitive file systems (e.g. Windows) which can cause failures when a file conflicts with a similarly named directory (e.g. LICENSE, license\LICENCE).
